### PR TITLE
ci: fix display digest step of build-image-release

### DIFF
--- a/.github/workflows/build-images-releases.yml
+++ b/.github/workflows/build-images-releases.yml
@@ -90,6 +90,7 @@ jobs:
         uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # v6.0.0
         with:
           path: image-digest/
+          pattern: "*image-digest *"
 
       - name: Image Digests Output
         shell: bash


### PR DESCRIPTION
Same as https://github.com/cilium/certgen/pull/483.